### PR TITLE
do not import IPython until needed

### DIFF
--- a/ipdbplugin.py
+++ b/ipdbplugin.py
@@ -7,7 +7,6 @@ drop into pdb on failure, use ``--ipdb-failures``.
 import sys
 import inspect
 import traceback
-import IPython
 from nose.plugins.base import Plugin
 
 class iPdb(Plugin):
@@ -55,6 +54,7 @@ class iPdb(Plugin):
         self.debug(err)
 
     def debug(self, err):
+        import IPython
         ec, ev, tb = err
         stdout = sys.stdout
         sys.stdout = sys.__stdout__


### PR DESCRIPTION
Some test suites (like mine) skip certain tests (like ones depending on matplotlib) if the test suite is run in interactive IPython mode. The easiest way to do this is to check if IPython has been imported, but I found after using ipdbplugin (which I love already) that IPython is imported upon initialization of nosetests. This pull request defers the IPython import until the plugin's debug method is invoked

cc @adamklein
