### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 What about running nose with a smarter interactive debugger?
 
-Use this and *never* risk yourself forgetting `import pdb; pdb.set_trace()` in your code again!
+Use this and *never* risk yourself forgetting `import ipdb; ipdb.set_trace()` in your code again!
 
 This plugin is 99.99% based on nose's [builtin debug plugin][1].
 


### PR DESCRIPTION
nose already supports dropping in to pdb (--pdb), so technically you'd avoid putting ipdb.set_trace() in your code. _shrug_
