### PR TITLE
Python 3 support.

### DIFF
--- a/ipdbplugin.py
+++ b/ipdbplugin.py
@@ -5,7 +5,6 @@ drop into pdb on failure, use ``--ipdb-failures``.
 """
 
 import sys
-import inspect
 import traceback
 from nose.plugins.base import Plugin
 
@@ -75,9 +74,6 @@ class iPdb(Plugin):
                 p = IPython.Debugger.Pdb(ip.options.colors)
 
             p.reset()
-            # inspect.trace() returns a list of frame information from this
-            # frame to the one that raised the exception being treated
-            frame, filename, line, func_name, ctx, idx = inspect.trace()[-1]
-            p.interaction(frame, tb)
+            p.interaction(None, tb)
         finally:
             sys.stdout = stdout


### PR DESCRIPTION
In Python 3.3, `inspect.trace()` returns an empty list which causes another
exception to be thrown. The source for `--pdb` in nose merely calls
`pdb.post_mortem(tb)`.  This function is, more or less,

```
p = pdb.Pdb()
p.reset()
p.interaction(None, tb)
```

This seems to fix the bug. In addition, the frame where the exception was
thrown does seem to be found anyway as all of the local variables are
accessible.
