### PR TITLE
Fix colors with IPython >= 4.1

### DIFF
--- a/ipdbplugin.py
+++ b/ipdbplugin.py
@@ -66,21 +66,22 @@ class iPdb(Plugin):
         traceback.print_exception(ec, ev, tb)
         sys.stderr.write('--------------------------------------------------------------------------------\n')
         try:
-            # The IPython API changed a bit so we should
-            # support the new version
-            if hasattr(IPython, 'InteractiveShell'):
-                if hasattr(IPython.InteractiveShell, 'instance'):
-                    shell = IPython.InteractiveShell.instance()
-                    p = IPython.core.debugger.Pdb(shell.colors)
-                else:
-                    shell = IPython.InteractiveShell()
+            try:
+                # ipython >= 1.0
+                from IPython.terminal.ipapp import TerminalIPythonApp
+                app = TerminalIPythonApp.instance()
+                app.initialize(argv=[])
+                p = IPython.core.debugger.Pdb(app.shell.colors)
+            except ImportError:
+                try:
+                    # 0.11 <= ipython <= 0.13
                     ip = IPython.core.ipapi.get()
                     p = IPython.core.debugger.Pdb(ip.colors)
-            # and keep support for older versions
-            else:
-                shell = IPython.Shell.IPShell(argv=[''])
-                ip = IPython.ipapi.get()
-                p = IPython.Debugger.Pdb(ip.options.colors)
+                except AttributeError:
+                    # ipython <= 0.10
+                    shell = IPython.Shell.IPShell(argv=[''])
+                    ip = IPython.ipapi.get()
+                    p = IPython.Debugger.Pdb(ip.options.colors)
 
             p.reset()
             # inspect.getinnerframes() returns a list of frames information


### PR DESCRIPTION
With the latest version of IPython (4.1.2), the debugger doesn't use colors anymore. Here are some snapshots when running `nosetests testsample.py --ipdb-f`:

IPython 4.1.2:
![without_colors](https://cloud.githubusercontent.com/assets/1680079/13813027/7956dd78-eb7f-11e5-9dbd-e84c8e7d8035.png)

IPython 4.0.3:
![with_colors](https://cloud.githubusercontent.com/assets/1680079/13813041/8bc12fae-eb7f-11e5-9d96-f6e0c665476f.png)

For some reason that I haven't had the time to fully investigate, `IPython.InteractiveShell` doesn't take colors properly into account whereas `IPython.terminal.interactiveshell.TerminalInteractiveShell` does.

I tested the changes on all major IPython versions from 0.10 to 4.2.1.