### PR TITLE
Start IPython instance with --no-banner option

### DIFF
--- a/ipdbplugin.py
+++ b/ipdbplugin.py
@@ -70,7 +70,7 @@ class iPdb(Plugin):
                 # ipython >= 1.0
                 from IPython.terminal.ipapp import TerminalIPythonApp
                 app = TerminalIPythonApp.instance()
-                app.initialize(argv=[])
+                app.initialize(argv=['--no-banner'])
                 p = IPython.core.debugger.Pdb(app.shell.colors)
             except ImportError:
                 try:


### PR DESCRIPTION
#19 had small problem: you get the IPython banner after the TRACEBACK section.

Here is snapshot from the recently 1.4.4 version just uploaded to pip.
![snapshot](https://cloud.githubusercontent.com/assets/1680079/13882939/c035938e-ed27-11e5-82fc-7370d745ffdb.png)
